### PR TITLE
Updates to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ to allow power switching.
   - Sanwa Supply: USB-HUB14GPH
   - Targus, Inc.: PAUH212
   - Hawking Technology: UH214
-  - B+B SmartWorx: UHR204
-  - B+B SmartWorx: USH304
+  - B+B SmartWorx (B+B Electronics): UHR204
+  - B+B SmartWorx (B+B Electronics): USH304
   - Belkin: F5U701
   - Linksys: USB2HUB4
 

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ to allow power switching.
   - Sanwa Supply: USB-HUB14GPH
   - Targus, Inc.: PAUH212
   - Hawking Technology: UH214
-  - B+B SmartWorx (B+B Electronics): UHR204
-  - B+B SmartWorx (B+B Electronics): USH304
+  - B+B SmartWorx (B&B Electronics): UHR204
+  - B+B SmartWorx (B&B Electronics): USH304
   - Belkin: F5U701
   - Linksys: USB2HUB4
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ to allow power switching.
   - Sanwa Supply: USB-HUB14GPH
   - Targus, Inc.: PAUH212
   - Hawking Technology: UH214
-  - B&B Electronics: UHR204
+  - B+B SmartWorx: UHR204
   - Belkin: F5U701
   - Linksys: USB2HUB4
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ to allow power switching.
   - Targus, Inc.: PAUH212
   - Hawking Technology: UH214
   - B+B SmartWorx: UHR204
+  - B+B SmartWorx: USH304
   - Belkin: F5U701
   - Linksys: USB2HUB4
 


### PR DESCRIPTION
- B&B Electronics was rebranded to B+B SmartWorx; README.md updated to reflect this
- Added another B+B hub